### PR TITLE
chore: use ES2023

### DIFF
--- a/src/compile/build.js
+++ b/src/compile/build.js
@@ -20,7 +20,9 @@ module.exports = ({ content, cwd }) =>
       sourcefile: 'index.js'
     },
     bundle: true,
-    ...MINIFY,
     write: false,
-    platform: 'node'
+    platform: 'node',
+    legalComments: 'eof',
+    target: 'es2023',
+    ...MINIFY
   })

--- a/src/compile/detect-dependencies.js
+++ b/src/compile/detect-dependencies.js
@@ -64,7 +64,7 @@ module.exports = code => {
   const dependencies = new Set()
 
   // Parse the code into an AST
-  const ast = acorn.parse(code, { ecmaVersion: 2020, sourceType: 'module' })
+  const ast = acorn.parse(code, { ecmaVersion: 2023, sourceType: 'module' })
 
   // Traverse the AST to find require and import statements
   walk.simple(ast, {

--- a/src/compile/transform-dependencies.js
+++ b/src/compile/transform-dependencies.js
@@ -4,7 +4,7 @@ const walk = require('acorn-walk')
 const acorn = require('acorn')
 
 module.exports = code => {
-  const ast = acorn.parse(code, { ecmaVersion: 2020, sourceType: 'module' })
+  const ast = acorn.parse(code, { ecmaVersion: 2023, sourceType: 'module' })
 
   let newCode = ''
   let lastIndex = 0


### PR DESCRIPTION
According with https://node.green/ Node.js 22.x is 100% supported with es2023